### PR TITLE
Update dependencies and gate on dependency conflicts

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
   :profiles {:dev     {:resource-paths ["conf/test"]}
              :uberjar {:aot :all}}
   :plugins [[jonase/eastwood "1.4.3"]
-            [lein-ancient "0.7.0"]
+            [lein-ancient "1.0.0"]
             [test2junit "1.4.4"]]
   :uberjar-exclusions [#"LICENSE" #"NOTICE"]
   :jvm-opts ["-Dlogback.configurationFile=/etc/iplant/de/logging/info-typer-logging.xml"])

--- a/project.clj
+++ b/project.clj
@@ -14,16 +14,43 @@
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "info-typer-standalone.jar"
+  ;; Fail the build on a new dependency conflict rather than printing a
+  ;; warning nobody reads.
+  :pedantic? :abort
+  ;; Records versions Leiningen already resolves, read off the resolved
+  ;; classpath rather than copied from lein's "Consider using these
+  ;; :managed-dependencies" hint -- that hint names the version that LOST the
+  ;; conflict, so pasting it would be a silent upgrade.
+  ;;
+  ;; The jackson-* entries hold the family where clj-jargon puts it. jargon-core
+  ;; is pinned :upgrade false at 4.3.7.0-RELEASE for iRODS compatibility and
+  ;; brings jackson 2.14.1. jackson-core sits higher because cheshire needs it
+  ;; there -- cheshire 6 throws at runtime against jackson-core 2.14.1. This
+  ;; asymmetry is deliberate and matches what main already resolved; do not
+  ;; "tidy" it by dropping core to match the rest. Unifying means moving jargon.
+  :managed-dependencies [[cheshire "5.13.0"]
+                         [clj-http "3.13.0"]
+                         [com.fasterxml.jackson.core/jackson-annotations "2.14.1"]
+                         [com.fasterxml.jackson.core/jackson-core "2.17.0"]
+                         [com.fasterxml.jackson.core/jackson-databind "2.14.1"]
+                         [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.14.1"]
+                         [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.14.1"]
+                         [com.google.guava/guava "16.0.1"]
+                         [commons-codec "1.16.1"]
+                         [org.apache.commons/commons-compress "1.8"]
+                         [prismatic/schema "1.1.12"]
+                         [ring/ring-codec "1.1.0"]
+                         [ring/ring-core "1.6.3"]]
   :dependencies [[org.clojure/clojure "1.12.5"]
                  [com.novemberain/langohr "5.6.0" :exclusions [org.slf4j/slf4j-api]]
                  [me.raynes/fs "1.4.6"]
-                 [org.cyverse/clj-jargon "3.1.5"
+                 [org.cyverse/clj-jargon "3.1.6"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
-                 [org.cyverse/clojure-commons "3.0.12" :exclusions [commons-logging]]
-                 [org.cyverse/common-cli "2.8.2"]
-                 [org.cyverse/heuristomancer "2.8.7"]
-                 [org.cyverse/service-logging "2.8.5"]
+                 [org.cyverse/clojure-commons "3.0.13" :exclusions [commons-logging]]
+                 [org.cyverse/common-cli "2.8.3"]
+                 [org.cyverse/heuristomancer "2.8.8"]
+                 [org.cyverse/service-logging "2.8.6"]
                  [org.slf4j/slf4j-api "2.0.18"]]
   :eastwood {:exclude-namespaces [:test-paths]
              :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}


### PR DESCRIPTION
Part of a fleet-wide pass over the DE Clojure repos to clear Leiningen's
"Possibly confusing dependencies" reports and bring dependencies current.
**14 warnings → 0.**

## Changes

- `build: normalize plugin and Clojure versions`
- `deps: update org.cyverse libraries and gate on dependency conflicts`

## The cider-nrepl leak is fixed at the source

Published `org.cyverse` poms used to declare `cider/cider-nrepl` at *compile*
scope, so a development REPL tool was landing on this service's runtime
classpath and inside its uberjar. Those libraries have since been re-released
with it removed, so bumping the pins was enough — **no exclusion workaround
needed**. Verified: 0 cider entries on the resolved classpath and 0 in the
built uberjar.

## A note on the jackson versions

This service depends on `clj-jargon`, which holds `databind`/`cbor`/`smile` at
the 2.14.1 that `jargon-core 4.3.7.0-RELEASE` brings — that artifact is pinned
`:upgrade false` for iRODS compatibility. `jackson-core` sits higher because
cheshire requires it there; cheshire 6 throws at runtime against jackson-core
2.14.1.

So the family is deliberately **not** uniform. That matches what `main` already
resolved, and the pins now make it explicit. The comment in `project.clj` warns
against "tidying" it by dropping `jackson-core` to match the rest — that looks
like a cleanup and would break JSON handling at runtime rather than at build
time. Unifying the family means moving jargon.

## Verification

```
confusing-dep warnings   14 -> 0
lein deps :tree          exit 0 (default, +dev,+test, +uberjar)
lein test                Ran 1 tests containing 19 assertions., 0 failures
lein uberjar             builds; 0 cider entries in the jar
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)